### PR TITLE
fix: correct Vestibule → Antechamber for Rank 9 room (issue #14)

### DIFF
--- a/src/GlobalState.tsx
+++ b/src/GlobalState.tsx
@@ -117,7 +117,7 @@ const StudioAdditionList = [
   "Classroom",
   "Solarium",
   "Dormitory",
-  "Vestibule",
+  "Antechamber",
   "Casino",
 ] as const;
 
@@ -683,7 +683,7 @@ const allUndefinedState: GlobalState = {
   "rooms.Classroom": undefined,
   "rooms.Solarium": undefined,
   "rooms.Dormitory": undefined,
-  "rooms.Vestibule": undefined,
+  "rooms.Antechamber": undefined,
   "rooms.Casino": undefined,
   "rooms.Planetarium": undefined,
   "rooms.Mechanarium": undefined,

--- a/src/MainQuiz.tsx
+++ b/src/MainQuiz.tsx
@@ -384,7 +384,7 @@ const studioAliasList: [StudioAddition, string[]][] = [
   ["Classroom", []],
   ["Solarium", []],
   ["Dormitory", []],
-  ["Vestibule", []],
+  ["Antechamber", []],
   ["Casino", []],
 ];
 
@@ -448,7 +448,7 @@ const QroughDraft = new QuizItemWrapper({
     new TritSetter({
       v: "roughDraftMoonDoor",
       condition: "locRoughDraft",
-      labelRight: "opened the moon door in the Vestibule",
+      labelRight: "opened the moon door in the Antechamber",
     }),
     new TritSetter({
       v: "roughDraft46",

--- a/src/Todo.tsx
+++ b/src/Todo.tsx
@@ -4134,16 +4134,16 @@ export const Todos: Todo[] = [
       confirm();
       say("The “prism” refers to the lanterns on rank 1 (see Atelier poster).");
       confirm();
-      say("The paths convene at the Vestibule.");
+      say("The paths convene at the Antechamber.");
       confirm();
       say("There is a red path, an orange path and a purple path.");
       confirmSol();
       say(
-        "Starting at the red, orange or purple lantern on rank one, reach the Vestibule without ever passing a lantern of a different color.",
+        "Starting at the red, orange or purple lantern on rank one, reach the Antechamber without ever passing a lantern of a different color.",
       );
       confirmReveal("Reveal what happens.");
       say(
-        "The moon door in the Vestibule can be opened. But a note will clarify that each was “not the true path”.",
+        "The moon door in the Antechamber can be opened. But a note will clarify that each was “not the true path”.",
       );
       solved("Mark the moon door as opened.", "roughDraftMoonDoor");
     },


### PR DESCRIPTION
## Summary
Fixes the middle Rank 9 room name from 'Vestibule' to 'Antechamber' (issue #14).

## Changes
- `src/Todo.tsx`: Updated 3 text references (lines 4137, 4142, 4146)
- `src/GlobalState.tsx`: Updated room key (line 120, 686)
- `src/MainQuiz.tsx`: Updated quiz data (lines 387, 451)

## Why
The middle Rank 9 room in the lantern path puzzle is called 'Vestibule' but should be 'Antechamber' to match the correct room name used elsewhere in the game.